### PR TITLE
Fix deletion logic in doubly linked list

### DIFF
--- a/challenge/4-delete_dnodeint/delete_dnodeint_at_index.c
+++ b/challenge/4-delete_dnodeint/delete_dnodeint_at_index.c
@@ -11,43 +11,28 @@
  */
 int delete_dnodeint_at_index(dlistint_t **head, unsigned int index)
 {
-	dlistint_t *saved_head;
-	dlistint_t *tmp;
-	unsigned int p;
+    dlistint_t *node;
+    unsigned int i;
 
-	if (*head == NULL)
-	{
-		return (-1);
-	}
-	saved_head = *head;
-	p = 0;
-	while (p < index && *head != NULL)
-	{
-		*head = (*head)->next;
-		p++;
-	}
-	if (p != index)
-	{
-		*head = saved_head;
-		return (-1);
-	}
-	if (0 == index)
-	{
-		tmp = (*head)->next;
-		free(*head);
-		*head = tmp;
-		if (tmp != NULL)
-		{
-			tmp->prev = NULL;
-		}
-	}
-	else
-	{
-		(*head)->prev->prev = (*head)->prev;
-		free(*head);
-		if ((*head)->next)
-			(*head)->next->prev = (*head)->prev;
-		*head = saved_head;
-	}
-	return (1);
+    if (head == NULL || *head == NULL)
+        return (-1);
+
+    node = *head;
+    for (i = 0; node != NULL && i < index; i++)
+        node = node->next;
+
+    if (node == NULL)
+        return (-1);
+
+    if (node->prev != NULL)
+        node->prev->next = node->next;
+    else
+        *head = node->next;
+
+    if (node->next != NULL)
+        node->next->prev = node->prev;
+
+    free(node);
+
+    return (1);
 }


### PR DESCRIPTION
## Summary
- stop the deletion routine from corrupting the list when removing a node in the middle
- correctly update neighbours and head pointer after removing the targeted node

## Testing
- `gcc -Wall -pedantic -Werror -Wextra -std=gnu89 main.c free_dlistint.c print_dlistint.c add_dnodeint_end.c delete_dnodeint_at_index.c -o delete_dnodeint`
- `./delete_dnodeint`


------
https://chatgpt.com/codex/tasks/task_e_68d4255cd14c83208c6608e6d9fdab04